### PR TITLE
Add download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The family consists of:
 Libertinus fonts are available under the terms of the Open Font License version
 1.1.
 
+A zip file containing the font files can be downloaded from the "Releases" page
+of the project on GitHub.
+
 Building
 --------
 To build the fonts, you need GNU Make, [FontForge][1] with Python support, and


### PR DESCRIPTION
This change tells the user that a zip file exists and where it is located.  That should make it easier for new users to find what they need to install the fonts.  (When I first started using this font, I did not know that a zip file existed.)